### PR TITLE
Missing config() calling in the constants.js

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,6 @@
+import { config } from 'dotenv'
+config();
+
 export const APP_PORT = process.env.APP_PORT || 3000
 export const JWT_SECRET = process.env.JWT_SECRET || 'a secret key'
 export const SALT_ROUNDS = process.env.SALT_ROUNDS || 10


### PR DESCRIPTION
I followed along the official tutorial and found that the APP_PORT change I made in .env file would not take effect with 'npm start'. Maybe this is because the constant.js file does not call config() from "dotenv" so that it will always take the default setting.