### PR TITLE
help students find typos quicker

### DIFF
--- a/test/challenges/03-registering-a-user.spec.js
+++ b/test/challenges/03-registering-a-user.spec.js
@@ -57,6 +57,7 @@ describe('03. Registering a User', () => {
 
         expect(user.properties.email).toEqual(email)
         expect(user.properties.name).toEqual(name)
+        expect(user.properties.password).toBeDefined()
         expect(user.properties.password).not.toEqual(password, 'Password should be hashed')
     })
 })


### PR DESCRIPTION
if `user.properties.password = undefined` i.e from a typo like `pasword` in following the example, then the test will pass, but the database check done by the course will fail.

the test `expect(user.properties.password).not.toEqual(password, 'Password should be hashed')` passes because `undefined <> password`