### PR TITLE
Parameter typo in all( ) function

### DIFF
--- a/src/services/favorite.service.js
+++ b/src/services/favorite.service.js
@@ -37,7 +37,7 @@ export default class FavoriteService {
    * @returns {Promise<Record<string, any>[]>}  An array of Movie objects
    */
   // tag::all[]
-  async all(userId, orderBy = 'title', order = 'ASC', limit = 6, skip = 0) {
+  async all(userId, sort = 'title', order = 'ASC', limit = 6, skip = 0) {
     // Open a new session
     const session = this.driver.session()
 
@@ -48,7 +48,7 @@ export default class FavoriteService {
         .*,
         favorite: true
       } AS movie
-      ORDER BY m.\`${orderBy}\` ${order}
+      ORDER BY m.\`${sort}\` ${order}
       SKIP $skip
       LIMIT $limit
     `, { userId, skip: int(skip), limit: int(limit) }))


### PR DESCRIPTION
Parameter for the all function was listed as sort:
* @param {string} sort The property to order the results by

The function signature used orderBy:
async all(userId, orderBy = 'title', order = 'ASC', limit = 6, skip = 0)

And the Cypher query also used orderBy:
ORDER BY m.\`${orderBy}\` ${order}

Changed them to use sort to be consistent with the GraphAcademy Course.